### PR TITLE
Fix first-run Star metrics branch initialization

### DIFF
--- a/.github/workflows/star-history.yml
+++ b/.github/workflows/star-history.yml
@@ -44,7 +44,7 @@ jobs:
           else
             git worktree add --detach "$metrics_dir"
             git -C "$metrics_dir" switch --orphan metrics
-            git -C "$metrics_dir" rm -rf .
+            git -C "$metrics_dir" rm -rf --ignore-unmatch -- .
           fi
           echo "directory=$metrics_dir" >> "$GITHUB_OUTPUT"
 

--- a/tests/test_star_history.py
+++ b/tests/test_star_history.py
@@ -29,6 +29,14 @@ class StubClient:
         return self.responses.pop(0)
 
 
+def test_workflow_allows_an_empty_first_metrics_branch() -> None:
+    workflow = (PRODUCT_ROOT / ".github" / "workflows" / "star-history.yml").read_text(
+        encoding="utf-8"
+    )
+
+    assert 'git -C "$metrics_dir" rm -rf --ignore-unmatch -- .' in workflow
+
+
 def _event(user_id: int, timestamp: str, login: str = "private-user") -> dict[str, Any]:
     return {"starred_at": timestamp, "user": {"id": user_id, "login": login}}
 


### PR DESCRIPTION
The first post-merge Star History run failed while creating the orphan `metrics` branch because `git rm -rf .` returns 128 when the orphan index is already empty.

This patch uses `--ignore-unmatch -- .` and adds a regression test for the workflow contract.

Verification:
- `tests/test_star_history.py`: 9 passed
- Ruff passed
- strict public-release audit passed (506 files)
- remote blobs match the locally tested files exactly