### PR TITLE
Fix explicit marker rendering for trend lines

### DIFF
--- a/runtime/runtime-manifest.json
+++ b/runtime/runtime-manifest.json
@@ -90,8 +90,8 @@
     },
     {
       "path": "src/origin_sciplot/origin_backend/scientific_renderer.py",
-      "size_bytes": 57610,
-      "sha256": "8abe5f8731fc8e7b1888cc1bd189d5779d2e49ca4f80eac14918ea43106acbbc"
+      "size_bytes": 57791,
+      "sha256": "14660e173dbab072c9391bc02e86765d5fc7a21460fe6f6833593c9e40de2716"
     },
     {
       "path": "src/origin_sciplot/origin_backend/session.py",
@@ -105,8 +105,8 @@
     },
     {
       "path": "src/origin_sciplot/origin_backend/verify_utils.py",
-      "size_bytes": 8483,
-      "sha256": "7aed33580b78e3939421e85a43f100d187abdeb1c030ff8fff92141311ae9e5a"
+      "size_bytes": 8758,
+      "sha256": "c458ee53c5cd6616f68a57987518b48c9725c195854334f7f85f3042196e7390"
     },
     {
       "path": "src/origin_sciplot/output_manager.py",
@@ -135,8 +135,8 @@
     },
     {
       "path": "src/origin_sciplot/scientific_preview.py",
-      "size_bytes": 62979,
-      "sha256": "9bdf692fd5e5f39e7a4bf8c69fc643c66182159fb60f7b992ae5328a0b33f48b"
+      "size_bytes": 63413,
+      "sha256": "b9625f7f53348ca91052dac099e5c5a6fcaf773b4fffd7fd950a85255f033c3a"
     },
     {
       "path": "src/origin_sciplot/scientific_visual.py",
@@ -145,8 +145,8 @@
     },
     {
       "path": "src/origin_sciplot/scientific_workflow.py",
-      "size_bytes": 144881,
-      "sha256": "9e0ea10c6f934457bb95d28cd5aaeff4081a58873af54d062fdef7f0ac5c0341"
+      "size_bytes": 145960,
+      "sha256": "e75e472e717d68d17e021848fe701f563a164ba98763f81586fe3551296736ee"
     },
     {
       "path": "src/origin_sciplot/template_registry.py",
@@ -190,8 +190,8 @@
     },
     {
       "path": "src/origin_sciplot/workers/run_template_worker.py",
-      "size_bytes": 17937,
-      "sha256": "62112cb50a8ff1c37071bced9fb1b2b40e02d441507d3c4393a572cf79962497"
+      "size_bytes": 18485,
+      "sha256": "89c69246fbac034e25f33366bcc52f22ecbeefb967daa0ccdd8f7567b358b5d7"
     },
     {
       "path": "src/origin_sciplot/xps_adaptive.py",

--- a/runtime/src/origin_sciplot/origin_backend/scientific_renderer.py
+++ b/runtime/src/origin_sciplot/origin_backend/scientific_renderer.py
@@ -206,6 +206,12 @@ def _prepare_origin_table(
                 color = "#A7ABAE"
                 line_style = 2
         plot_type = _origin_plot_type(spec.plot_kind)
+        if (
+            spec.plot_kind == "line"
+            and spec.display_plan.show_markers
+            and series.series_role == "data"
+        ):
+            plot_type = "y"
         if spec.plot_kind == "pl_decay":
             plot_type = "l" if series.series_role == "fit" else "s"
         series_plans.append(

--- a/runtime/src/origin_sciplot/origin_backend/verify_utils.py
+++ b/runtime/src/origin_sciplot/origin_backend/verify_utils.py
@@ -130,11 +130,17 @@ def verify_symbol_style(
     *,
     expected_size_pt: float,
     expected_edge_percent: float,
+    expected_kind: int = 2,
     tolerance: float = 0.05,
-) -> dict[str, float]:
+) -> dict[str, float | int]:
     """Read back a scatter symbol's point size and radius-relative edge thickness."""
+    kind = int(plot.symbol_kind)
     size = _read_plot_option(op, plot, "-z", "__osc_symbol_size")
     edge = _read_plot_option(op, plot, "-kh", "__osc_symbol_edge")
+    if kind != expected_kind:
+        raise RuntimeError(
+            f"Origin symbol kind verification failed: {kind}, expected {expected_kind}"
+        )
     if abs(size - expected_size_pt) > tolerance:
         raise RuntimeError(
             f"Origin symbol size verification failed: {size:g} pt, expected {expected_size_pt:g} pt"
@@ -144,7 +150,11 @@ def verify_symbol_style(
             "Origin symbol edge verification failed: "
             f"{edge:g}% of radius, expected {expected_edge_percent:g}%"
         )
-    return {"symbol_size_pt": size, "symbol_edge_percent_of_radius": edge}
+    return {
+        "symbol_kind": kind,
+        "symbol_size_pt": size,
+        "symbol_edge_percent_of_radius": edge,
+    }
 
 
 def verify_page_and_layer(

--- a/runtime/src/origin_sciplot/scientific_preview.py
+++ b/runtime/src/origin_sciplot/scientific_preview.py
@@ -393,12 +393,21 @@ def _draw_line_profiles(axis: Any, frame: Any, preparation: ScientificPreparatio
                 zorder=3,
             )
         else:
+            show_markers = (
+                spec.plot_kind == "line"
+                and spec.display_plan.show_markers
+                and series.series_role == "data"
+            )
             target.plot(
                 x,
                 y,
                 color=color,
                 linewidth=style.plot_line_pt,
                 linestyle=line_style,
+                marker="o" if show_markers else None,
+                markersize=marker_size if show_markers else None,
+                markerfacecolor=color if show_markers else None,
+                markeredgecolor=color if show_markers else None,
                 label=label,
                 zorder=3,
             )

--- a/runtime/src/origin_sciplot/scientific_workflow.py
+++ b/runtime/src/origin_sciplot/scientific_workflow.py
@@ -186,6 +186,7 @@ class ScientificDisplayPlan:
     bar_inner_width: float
     category_label_rotation_deg: float = 0.0
     figure_style: AdaptiveOriginStyle | None = None
+    show_markers: bool = False
 
 
 @dataclass(frozen=True)
@@ -323,6 +324,35 @@ def apply_scientific_text_overrides(
         preparation,
         plot_spec=overridden,
         plan_digest=_scientific_plan_digest(preparation, overridden),
+    )
+
+
+def apply_scientific_marker_override(
+    preparation: ScientificPreparation,
+    *,
+    show_markers: bool,
+) -> ScientificPreparation:
+    """Freeze an explicit marker choice for a generic trend line.
+
+    This intentionally excludes spectra, diffraction patterns, fits, reference
+    lines, and every non-trend route.  Those routes keep their own verified
+    symbol contracts.
+    """
+
+    spec = preparation.plot_spec
+    if preparation.template_id != "trend" or spec.plot_kind != "line":
+        raise ScientificWorkflowError(
+            "marker_override_unsupported",
+            "Explicit line markers are currently available only for the trend template.",
+        )
+    overridden_display = replace(spec.display_plan, show_markers=bool(show_markers))
+    overridden_spec = replace(spec, display_plan=overridden_display)
+    if overridden_spec == spec:
+        return preparation
+    return replace(
+        preparation,
+        plot_spec=overridden_spec,
+        plan_digest=_scientific_plan_digest(preparation, overridden_spec),
     )
 
 

--- a/runtime/src/origin_sciplot/workers/run_template_worker.py
+++ b/runtime/src/origin_sciplot/workers/run_template_worker.py
@@ -26,6 +26,7 @@ from origin_sciplot.output_manager import RunOutput
 from origin_sciplot.scientific_workflow import (
     ScientificColumnMapping,
     ScientificWorkflowError,
+    apply_scientific_marker_override,
     apply_scientific_palette_override,
     apply_scientific_text_overrides,
     load_scientific_frame,
@@ -66,6 +67,10 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--column-mapping-json")
     parser.add_argument("--text-overrides-json")
     parser.add_argument("--palette-id")
+    marker_group = parser.add_mutually_exclusive_group()
+    marker_group.add_argument("--show-markers", dest="show_markers", action="store_true")
+    marker_group.add_argument("--hide-markers", dest="show_markers", action="store_false")
+    parser.set_defaults(show_markers=None)
     parser.set_defaults(keep_origin_open=True)
     parser.add_argument("--keep-origin-open", dest="keep_origin_open", action="store_true")
     parser.add_argument("--close-origin", dest="keep_origin_open", action="store_false")
@@ -228,6 +233,11 @@ def main(argv: list[str] | None = None) -> int:
                 scientific_analysis = apply_scientific_palette_override(
                     scientific_analysis,
                     palette_id=args.palette_id,
+                )
+            if args.show_markers is not None:
+                scientific_analysis = apply_scientific_marker_override(
+                    scientific_analysis,
+                    show_markers=args.show_markers,
                 )
             selected_renderer_template_id = manifest.id
             if scientific_analysis.requires_confirmation:

--- a/skill/editaplot/scripts/editaplot.py
+++ b/skill/editaplot/scripts/editaplot.py
@@ -92,6 +92,20 @@ def build_parser() -> argparse.ArgumentParser:
     plan_parser.add_argument("--x-title")
     plan_parser.add_argument("--y-title")
     plan_parser.add_argument("--palette-id", help="Freeze a compatible palette from `palettes`")
+    marker_group = plan_parser.add_mutually_exclusive_group()
+    marker_group.add_argument(
+        "--show-markers",
+        dest="show_markers",
+        action="store_true",
+        help="Freeze line plus symbols for a generic trend plot",
+    )
+    marker_group.add_argument(
+        "--hide-markers",
+        dest="show_markers",
+        action="store_false",
+        help="Freeze a line-only generic trend plot",
+    )
+    plan_parser.set_defaults(show_markers=None)
     plan_parser.add_argument(
         "--target-output",
         default="editable Origin figure and publication exports",
@@ -318,6 +332,7 @@ def main(argv: list[str] | None = None) -> int:
                 x_title=args.x_title,
                 y_title=args.y_title,
                 palette_id=args.palette_id,
+                show_markers=args.show_markers,
                 mapping=mapping,
                 engine_home=args.engine_home,
             )

--- a/skill/editaplot/scripts/editaplot_core.py
+++ b/skill/editaplot/scripts/editaplot_core.py
@@ -1301,6 +1301,7 @@ def build_plan(
     x_title: str | None = None,
     y_title: str | None = None,
     palette_id: str | None = None,
+    show_markers: bool | None = None,
     mapping: dict[str, Any] | None = None,
     engine_home: str | Path | None = None,
 ) -> dict[str, Any]:
@@ -1311,6 +1312,7 @@ def build_plan(
     try:
         from origin_sciplot.palette_catalog import get_palette, palette_to_dict
         from origin_sciplot.scientific_workflow import (
+            apply_scientific_marker_override,
             apply_scientific_palette_override,
             apply_scientific_text_overrides,
         )
@@ -1371,6 +1373,25 @@ def build_plan(
         except Exception as exc:  # noqa: BLE001 - normalize engine validation errors
             code = getattr(exc, "code", "palette_invalid")
             raise EditaPlotError(code, str(exc)) from exc
+    marker_contract: dict[str, Any] = {}
+    if show_markers is not None:
+        if template_id == "xps":
+            raise EditaPlotError(
+                "marker_override_unsupported",
+                "Explicit line markers are currently available only for the trend template.",
+            )
+        try:
+            frozen_payload = apply_scientific_marker_override(
+                frozen_payload,
+                show_markers=show_markers,
+            )
+            marker_contract = {
+                "mode": "line_and_symbol" if show_markers else "line_only",
+                "show_markers": bool(show_markers),
+            }
+        except Exception as exc:  # noqa: BLE001 - normalize engine validation errors
+            code = getattr(exc, "code", "marker_override_invalid")
+            raise EditaPlotError(code, str(exc)) from exc
     plot_spec = getattr(frozen_payload, "plot_spec", None)
     display_transform = getattr(plot_spec, "display_transform", "identity") if plot_spec else "identity"
     if hasattr(plot_spec, "visual_profile"):
@@ -1404,6 +1425,7 @@ def build_plan(
             "target_output": target_output.strip(),
             "axis_title_overrides": axis_title_overrides,
             "palette": palette_contract,
+            **({"line_markers": marker_contract} if marker_contract else {}),
         },
         "template": {
             "id": template_id,
@@ -1492,6 +1514,9 @@ def build_worker_command(
     palette = plan.get("figure_contract", {}).get("palette")
     if isinstance(palette, dict) and palette.get("palette_id"):
         command.extend(("--palette-id", str(palette["palette_id"])))
+    line_markers = plan.get("figure_contract", {}).get("line_markers")
+    if isinstance(line_markers, dict) and isinstance(line_markers.get("show_markers"), bool):
+        command.append("--show-markers" if line_markers["show_markers"] else "--hide-markers")
     env = dict(os.environ)
     source_path = str(root / "src")
     env["PYTHONPATH"] = source_path + (os.pathsep + env["PYTHONPATH"] if env.get("PYTHONPATH") else "")

--- a/tests/test_editaplot.py
+++ b/tests/test_editaplot.py
@@ -2156,6 +2156,124 @@ def test_plan_freezes_palette_and_passes_it_to_worker() -> None:
     assert command[index + 1] == "ocean_coral"
 
 
+def test_explicit_trend_markers_are_frozen_and_verified_as_origin_symbols() -> None:
+    source = ENGINE / "templates" / "trend" / "example_standard.csv"
+    marked_plan = build_plan(
+        source,
+        template_id="trend",
+        claim="The teaching series show progression across the measured steps.",
+        evidence_role="trend",
+        show_markers=True,
+        engine_home=ENGINE,
+    )
+    line_only_plan = build_plan(
+        source,
+        template_id="trend",
+        claim="The teaching series show progression across the measured steps.",
+        evidence_role="trend",
+        show_markers=False,
+        engine_home=ENGINE,
+    )
+
+    assert marked_plan["figure_contract"]["line_markers"] == {
+        "mode": "line_and_symbol",
+        "show_markers": True,
+    }
+    assert line_only_plan["figure_contract"]["line_markers"] == {
+        "mode": "line_only",
+        "show_markers": False,
+    }
+    marked_command, _env, _root = build_worker_command(marked_plan, engine_home=ENGINE)
+    line_only_command, _env, _root = build_worker_command(line_only_plan, engine_home=ENGINE)
+    assert "--show-markers" in marked_command
+    assert "--hide-markers" in line_only_command
+
+    from origin_sciplot.origin_backend.scientific_renderer import (
+        _figure_style,
+        _prepare_origin_table,
+        _verify_plots,
+    )
+    from origin_sciplot.scientific_workflow import (
+        apply_scientific_marker_override,
+        load_scientific_frame,
+        prepare_scientific,
+    )
+
+    preparation = prepare_scientific(source, "trend")
+    marked = apply_scientific_marker_override(preparation, show_markers=True)
+    line_only = apply_scientific_marker_override(preparation, show_markers=False)
+    frame = load_scientific_frame(source, marked)
+    marked_table = _prepare_origin_table(frame, marked)
+    line_only_table = _prepare_origin_table(frame, line_only)
+
+    assert {series.plot_type for series in marked_table.series} == {"y"}
+    assert all(series.marker_size_pt > 0 for series in marked_table.series)
+    assert {series.plot_type for series in line_only_table.series} == {"l"}
+
+    style = _figure_style(marked)
+
+    class FakeOrigin:
+        def __init__(self) -> None:
+            self.values: dict[str, float] = {}
+
+        def lt_float(self, name: str) -> float:
+            return self.values[name]
+
+    fake_origin = FakeOrigin()
+
+    class FakeLayer:
+        def LT_execute(self, command: str) -> bool:
+            variable = command.split()[-1].rstrip(";}")
+            if " -d " in command:
+                value = 0.0
+            elif " -w " in command:
+                value = style.plot_line_width_pt * 500.0
+            elif " -z " in command:
+                value = marked.plot_spec.display_plan.marker_size_pt
+            elif " -kh " in command:
+                value = 50.0
+            else:  # pragma: no cover - documents the exact readback surface used here
+                raise AssertionError(command)
+            fake_origin.values[variable] = value
+            return True
+
+    class FakePlot:
+        def __init__(self, name: str) -> None:
+            self.name = name
+            self.layer = FakeLayer()
+            self.transparency = 0.0
+            self.symbol_kind = 2
+
+        def lt_range(self) -> str:
+            return self.name
+
+    marked_plots = {item.label: FakePlot(item.label) for item in marked_table.series}
+    marked_state = _verify_plots(
+        fake_origin,
+        marked_table,
+        marked_plots,
+        {},
+        {},
+        style,
+    )
+    assert set(marked_state["symbols"]) == {item.label for item in marked_table.series}
+    assert all(
+        value["symbol_size_pt"] > 0 for value in marked_state["symbols"].values()
+    )
+    assert all(value["symbol_kind"] == 2 for value in marked_state["symbols"].values())
+
+    line_only_plots = {item.label: FakePlot(item.label) for item in line_only_table.series}
+    line_only_state = _verify_plots(
+        fake_origin,
+        line_only_table,
+        line_only_plots,
+        {},
+        {},
+        style,
+    )
+    assert line_only_state["symbols"] == {}
+
+
 def test_palette_override_does_not_weaken_xps_contract() -> None:
     with pytest.raises(EditaPlotError, match="XPS keeps"):
         build_plan(


### PR DESCRIPTION
## Summary

This PR fixes an issue where a user could explicitly request a line plot with data-point markers, but the generated Origin figure contained only a plain line.

## Root cause

The issue existed in both the planning and rendering layers:

- The RenderPlan did not preserve an explicit marker requirement.
- Generic line plots were always mapped to the Origin `l` plot type, while symbol styling was only applied to `s` and `y` plots.

## Changes

- Added an explicit `show_markers` contract to the planning workflow.
- Explicit trend lines with markers are now rendered using Origin plot type `y`.
- Plain lines remain `l`.
- Scatter plots remain `s`.
- Fit curves, reference lines, XRD patterns, and continuous spectra are not automatically given markers.
- Added Origin symbol-kind readback and related regression checks.

## Validation

Tested with Origin 2024b using a full render and verification workflow:

- Origin Automation connection succeeded.
- OPJU, PNG, PDF, and TIF were generated.
- Programmatic verification passed.
- Source-data SHA-256 remained unchanged.
- Origin readback:
  - `plot_type="y"`
  - `symbol_kind=2`
  - `symbol_size=7.0 pt`
- Human visual QA confirmed that all five markers were visible and matched the line color.
- Existing plain-line behavior was preserved.

No Origin installation or configuration was modified.