### PR TITLE
Prefer heatmaps for dense matrices

### DIFF
--- a/skill/editaplot/scripts/editaplot_core.py
+++ b/skill/editaplot/scripts/editaplot_core.py
@@ -864,6 +864,28 @@ def _score_candidate(
     category_count = int(table["first_category_unique_count"])
     long_label = int(table["maximum_category_label_length"])
     all_nonnegative = bool(table["all_numeric_values_nonnegative"])
+    dense_matrix_without_explicit_intent = (
+        "matrix_candidate" in layouts
+        and category_count >= 12
+        and numeric_count >= 12
+        and not any(_intent_match(item, intent) for item in category_templates)
+    )
+
+    if (
+        dense_matrix_without_explicit_intent
+        and template_id
+        in {
+            "bar",
+            "horizontal_bar",
+            "stacked_bar",
+            "percent_stacked_bar",
+            "pie",
+            "radar",
+        }
+    ):
+        score -= 0.18
+        reason_codes.append("dense_matrix_heatmap_route_preferred")
+        reasons.append("检测到高维类别矩阵；默认采用热力图，避免生成不可读的超密集柱形或雷达图。")
 
     if template_id == "bar" and "category_wide" in layouts:
         score += 0.05
@@ -899,6 +921,10 @@ def _score_candidate(
             score += 0.12
             reason_codes.append("matrix_candidate_match")
             reasons.append("类别 × 数值系列的矩形结构适合颜色矩阵。")
+            if dense_matrix_without_explicit_intent:
+                score += 0.16
+                reason_codes.append("dense_matrix_match")
+                reasons.append("行列均达到 12 个以上，颜色矩阵比逐系列图形更清晰。")
         else:
             score -= 0.30
         if "confusion_matrix" in layouts and _intent_match("confusion_matrix", intent):

--- a/tests/test_editaplot.py
+++ b/tests/test_editaplot.py
@@ -167,6 +167,22 @@ def test_ambiguous_numeric_xy_does_not_auto_select() -> None:
     assert "top_score_below_threshold" in result["auto_selection"]["gate_reasons"]
 
 
+def test_dense_matrix_prefers_heatmap_without_overriding_explicit_chart_intent() -> None:
+    source = EXAMPLES / "gallery" / "heatmap_dense_30x30.csv"
+
+    automatic = recommend_charts(source, engine_home=ENGINE)
+    assert automatic["candidates"][0]["template_id"] == "heatmap"
+    assert automatic["auto_selection"]["allowed"] is True
+    assert "dense_matrix_match" in automatic["candidates"][0]["reason_codes"]
+
+    explicit_bar = recommend_charts(
+        source,
+        intent="ranking with long labels",
+        engine_home=ENGINE,
+    )
+    assert explicit_bar["candidates"][0]["template_id"] == "horizontal_bar"
+
+
 def test_recommend_limit_one_still_uses_full_runner_up_margin(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## 修复

最终新手路径复测发现：在没有额外意图提示时，30×30 类别矩阵虽然会把热力图列为候选，但横向条形图仍排在第一。对这种高维结构，柱形图会不可读。

现在的规则是：

- 行与数值列均达到 12 个以上、且未明确指定图型时，优先选择热力图
- 用户明确指定柱形图、横向条形图等其他图型时，仍服从用户意图
- 原始数据保持只读，识别阶段不调用 Origin

## 验证

- 定向测试：14 passed
- 全量测试：543 passed，1 skipped
- Ruff：通过
- 严格公开发布审计：606 个文件，8,507,648 bytes，0 errors
- 实测 30×30 示例：heatmap score 0.99，margin 0.2872，自动选择通过